### PR TITLE
Avoid https://github.com/xanzy/go-gitlab/issues/632

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,9 +12,10 @@ import (
 )
 
 type envCfg struct {
+  ConfigFile     string `split_words:"true" default:"./config.json"`
+  Dryrun         bool
   GitlabEndpoint string `split_words:"true"`
   GitlabToken    string `split_words:"true" required:"true"`
-  ConfigFile     string `split_words:"true" default:"./config.json"`
   Verbose        bool
 }
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,6 +18,9 @@ var syncCmd = &cobra.Command{
         logger.Fatal(err)
       }
     }
+    if env.Dryrun == true {
+      logger.Infof("DRYRUN: No changes will be implemented.")
+    }
 
     manager := gl.NewProjectManager(
       logger.WithField("module", "project_manager"),
@@ -38,17 +41,17 @@ var syncCmd = &cobra.Command{
       logger.Infof("Updating project #%d: %s", index + 1, project.FullPath)
 
       // Update branches of current project
-      if err := manager.EnsureBranchesAndProtection(project); err != nil {
+      if err := manager.EnsureBranchesAndProtection(project, env.Dryrun); err != nil {
         logger.Errorf("failed to ensure branches of repo %v: %v", project.FullPath, err)
       }
 
       // Update general settings of current project
-      if err := manager.UpdateProjectSettings(project); err != nil {
+      if err := manager.UpdateProjectSettings(project, env.Dryrun); err != nil {
         logger.Errorf("failed to update project settings of repo %v: %v", project.FullPath, err)
       }
 
       // Update approval settings of current project
-      if err := manager.UpdateProjectApprovalSettings(project); err != nil {
+      if err := manager.UpdateProjectApprovalSettings(project, env.Dryrun); err != nil {
         logger.Errorf("failed to update approval settings of repo %v: %v", project.FullPath, err)
       }
     }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -18,7 +18,7 @@ var syncCmd = &cobra.Command{
         logger.Fatal(err)
       }
     }
-    if env.Dryrun == true {
+    if env.Dryrun {
       logger.Infof("DRYRUN: No changes will be implemented.")
     }
 

--- a/pkg/gitlab/types.go
+++ b/pkg/gitlab/types.go
@@ -14,7 +14,9 @@ type Project struct {
 }
 
 type groupsClient interface {
+  GetGroup(gid interface{}, options ...gitlab.OptionFunc) (*gitlab.Group, *gitlab.Response, error)
   ListGroupProjects(gid interface{}, opt *gitlab.ListGroupProjectsOptions, options ...gitlab.OptionFunc) ([]*gitlab.Project, *gitlab.Response, error)
+  ListSubgroups(gid interface{}, opt *gitlab.ListSubgroupsOptions, options ...gitlab.OptionFunc) ([]*gitlab.Group, *gitlab.Response, error)
 }
 
 type projectsClient interface {
@@ -35,6 +37,12 @@ type branchesClient interface {
 
 var (
   listGroupProjectOps = &gitlab.ListGroupProjectsOptions{
+    ListOptions: gitlab.ListOptions{
+      PerPage: 100,
+    },
+  }
+
+  listSubgroupOps = &gitlab.ListSubgroupsOptions{
     ListOptions: gitlab.ListOptions{
       PerPage: 100,
     },


### PR DESCRIPTION
Circumvent Go-Gitlab [Issue 632](https://github.com/xanzy/go-gitlab/issues/632) by avoiding urlencoded strings with a recursive group/subgroup lookup method.